### PR TITLE
Added NYC contact parsing and moved reseller to own contact

### DIFF
--- a/error.go
+++ b/error.go
@@ -121,6 +121,10 @@ func isExtNotFoundDomain(data, extension string) bool {
 		if strings.Contains(data, "not found") {
 			return true
 		}
+	case "com", "net":
+		if strings.Contains(data, "No match for") {
+			return true
+		}
 	}
 
 	return false

--- a/parser.go
+++ b/parser.go
@@ -189,35 +189,39 @@ func Parse(text string) (whoisInfo WhoisInfo, err error) { //nolint:cyclop
 	domain.Status = xslice.Unique(domain.Status).([]string)
 
 	whoisInfo.Domain = domain
-	if !reflect.DeepEqual(*registrar, Contact{}) {
+	if !isContactEmpty(registrar) {
 		whoisInfo.Registrar = registrar
 	}
 
-	if !reflect.DeepEqual(*registrant, Contact{}) {
+	if !isContactEmpty(registrant) {
 		whoisInfo.Registrant = registrant
 	}
 
-	if !reflect.DeepEqual(*administrative, Contact{}) {
+	if !isContactEmpty(administrative) {
 		whoisInfo.Administrative = administrative
 	}
 
-	if !reflect.DeepEqual(*technical, Contact{}) {
+	if !isContactEmpty(technical) {
 		whoisInfo.Technical = technical
 	}
 
-	if !reflect.DeepEqual(*billing, Contact{}) {
+	if !isContactEmpty(billing) {
 		whoisInfo.Billing = billing
 	}
 
-	if !reflect.DeepEqual(*reseller, Contact{}) {
+	if !isContactEmpty(reseller) {
 		whoisInfo.Reseller = reseller
 	}
 
-	if !reflect.DeepEqual(*nyc, Contact{}) {
+	if !isContactEmpty(nyc) {
 		whoisInfo.NYC = nyc
 	}
 
 	return
+}
+
+func isContactEmpty(c *Contact) bool {
+	return reflect.DeepEqual(*c, Contact{})
 }
 
 // parseContact do parse contact info

--- a/parser.go
+++ b/parser.go
@@ -63,6 +63,8 @@ func Parse(text string) (whoisInfo WhoisInfo, err error) { //nolint:cyclop
 	administrative := &Contact{}
 	technical := &Contact{}
 	billing := &Contact{}
+	reseller := &Contact{}
+	nyc := &Contact{}
 
 	domain.Name, _ = idna.ToASCII(name)
 	domain.Extension, _ = idna.ToASCII(extension)
@@ -149,8 +151,6 @@ func Parse(text string) (whoisInfo WhoisInfo, err error) { //nolint:cyclop
 			}
 		case "referral_url":
 			registrar.ReferralURL = value
-		case "reseller_name":
-			domain.Reseller = value
 		default:
 			name = clearKeyName(name)
 			if !strings.Contains(name, " ") {
@@ -174,6 +174,10 @@ func Parse(text string) (whoisInfo WhoisInfo, err error) { //nolint:cyclop
 				parseContact(technical, name, value)
 			} else if ns[0] == "bill" || ns[0] == "billing" {
 				parseContact(billing, name, value)
+			} else if ns[0] == "reseller" {
+				parseContact(reseller, name, value)
+			} else if ns[0] == "nyc" {
+				parseContact(nyc, name, value)
 			}
 		}
 	}
@@ -203,6 +207,14 @@ func Parse(text string) (whoisInfo WhoisInfo, err error) { //nolint:cyclop
 
 	if !reflect.DeepEqual(*billing, Contact{}) {
 		whoisInfo.Billing = billing
+	}
+
+	if !reflect.DeepEqual(*reseller, Contact{}) {
+		whoisInfo.Reseller = reseller
+	}
+
+	if !reflect.DeepEqual(*nyc, Contact{}) {
+		whoisInfo.NYC = nyc
 	}
 
 	return

--- a/rule.go
+++ b/rule.go
@@ -187,7 +187,5 @@ var (
 		"registrant abuse contact email":         "registrant_email",
 		"registrant attention":                   "registrant_email",
 		"registrant nexus category":              "registrant_extended_nexus_category",
-		"registrant application purpose":         "registrant_extended_application_purpose",
-		"reseller":                               "reseller_name",
-	}
+		"registrant application purpose":         "registrant_extended_application_purpose"}
 )

--- a/struct.go
+++ b/struct.go
@@ -29,6 +29,8 @@ type WhoisInfo struct {
 	Administrative *Contact `json:"administrative,omitempty"`
 	Technical      *Contact `json:"technical,omitempty"`
 	Billing        *Contact `json:"billing,omitempty"`
+	Reseller       *Contact `json:"reseller,omitempty"`
+	NYC            *Contact `json:"nyc,omitempty"`
 }
 
 // Domain storing domain name info

--- a/testdata/noterror/README.md
+++ b/testdata/noterror/README.md
@@ -138,6 +138,7 @@ If there is any problem, please feel free to open a new issue.
 | .nl | [google.nl](nl_google.nl) | [google.nl](nl_google.nl.json) | √ |
 | .nu | [google.nu](nu_google.nu) | [google.nu](nu_google.nu.json) | √ |
 | .nu | [nic.nu](nu_nic.nu) | [nic.nu](nu_nic.nu.json) | √ |
+| .nyc | [godaddy.nyc](nyc_godaddy.nyc) | [godaddy.nyc](nyc_godaddy.nyc.json) | √ |
 | .nz | [gre.nz](nz_gre.nz) | [gre.nz](nz_gre.nz.json) | √ |
 | .nz | [vote.nz](nz_vote.nz) | [vote.nz](nz_vote.nz.json) | √ |
 | .org | [apache.org](org_apache.org) | [apache.org](org_apache.org.json) | √ |

--- a/testdata/noterror/cat_git.cat.json
+++ b/testdata/noterror/cat_git.cat.json
@@ -18,8 +18,7 @@
         "updated_date": "2019-09-18T15:20:27Z",
         "updated_date_in_time": "2019-09-18T15:20:27Z",
         "expiration_date": "2019-11-17T16:11:05Z",
-        "expiration_date_in_time": "2019-11-17T16:11:05Z",
-        "reseller": "Netsto Limited"
+        "expiration_date_in_time": "2019-11-17T16:11:05Z"
     },
     "registrar": {
         "id": "81",
@@ -64,5 +63,8 @@
         "phone": "REDACTED FOR PRIVACY",
         "fax": "REDACTED FOR PRIVACY",
         "email": "0a099929a74cb35f7f1301344a022505-11466636@contact.gandi.net"
+    },
+    "reseller": {
+        "organization": "Netsto Limited"
     }
 }

--- a/testdata/noterror/com_rockcreekcc.com.json
+++ b/testdata/noterror/com_rockcreekcc.com.json
@@ -19,8 +19,7 @@
         "updated_date": "2021-05-03T20:23:19Z",
         "updated_date_in_time": "2021-05-03T20:23:19Z",
         "expiration_date": "2022-07-12T15:48:26Z",
-        "expiration_date_in_time": "2022-07-12T15:48:26Z",
-        "reseller": "Sterling Communications, Inc."
+        "expiration_date_in_time": "2022-07-12T15:48:26Z"
     },
     "registrar": {
         "id": "69",
@@ -64,5 +63,8 @@
         "phone": "REDACTED FOR PRIVACY",
         "fax": "REDACTED FOR PRIVACY",
         "email": "redacted for privacy"
+    },
+    "reseller": {
+        "organization": "Sterling Communications, Inc."
     }
 }

--- a/testdata/noterror/mobi_git.mobi.json
+++ b/testdata/noterror/mobi_git.mobi.json
@@ -19,8 +19,7 @@
         "updated_date": "2019-08-25T04:21:56Z",
         "updated_date_in_time": "2019-08-25T04:21:56Z",
         "expiration_date": "2020-05-19T03:25:15Z",
-        "expiration_date_in_time": "2020-05-19T03:25:15Z",
-        "reseller": "Rebel.com"
+        "expiration_date_in_time": "2020-05-19T03:25:15Z"
     },
     "registrar": {
         "id": "600",
@@ -67,5 +66,8 @@
         "phone": "REDACTED FOR PRIVACY",
         "fax": "REDACTED FOR PRIVACY",
         "email": "redacted for privacy"
+    },
+    "reseller": {
+        "organization": "Rebel.com"
     }
 }

--- a/testdata/noterror/net_gandi.net.json
+++ b/testdata/noterror/net_gandi.net.json
@@ -24,8 +24,7 @@
         "updated_date": "2019-02-07T09:22:28Z",
         "updated_date_in_time": "2019-02-07T09:22:28Z",
         "expiration_date": "2025-05-21T14:09:56Z",
-        "expiration_date_in_time": "2025-05-21T14:09:56Z",
-        "reseller": "GANDI SAS"
+        "expiration_date_in_time": "2025-05-21T14:09:56Z"
     },
     "registrar": {
         "id": "81",
@@ -71,5 +70,8 @@
         "phone": "REDACTED FOR PRIVACY",
         "fax": "REDACTED FOR PRIVACY",
         "email": "3521bef593b0080b0644bce75aa22a5d-248842@contact.gandi.net"
+    },
+    "reseller": {
+        "organization": "GANDI SAS"
     }
 }

--- a/testdata/noterror/net_hexonet.net.json
+++ b/testdata/noterror/net_hexonet.net.json
@@ -19,8 +19,7 @@
         "updated_date": "2017-02-28T09:53:46Z",
         "updated_date_in_time": "2017-02-28T09:53:46Z",
         "expiration_date": "2021-01-20T13:40:16Z",
-        "expiration_date_in_time": "2021-01-20T13:40:16Z",
-        "reseller": "HEXONET GmbH http://www.hexonet.net"
+        "expiration_date_in_time": "2021-01-20T13:40:16Z"
     },
     "registrar": {
         "id": "1387",
@@ -61,5 +60,8 @@
         "country": "REDACTED FOR PRIVACY",
         "phone": "REDACTED FOR PRIVACY",
         "email": "contact via https://www.1api.net/send-message/hexonet.net/tech"
+    },
+    "reseller": {
+        "organization": "HEXONET GmbH http://www.hexonet.net"
     }
 }

--- a/testdata/noterror/nl_git.nl.json
+++ b/testdata/noterror/nl_git.nl.json
@@ -17,5 +17,9 @@
     "registrar": {
         "name": "Realtime Register",
         "street": "Ceintuurbaan 32a, 8024AA ZWOLLE, Netherlands"
+    },
+    "reseller": {
+        "name": "Yourhosting",
+        "street": "Ceintuurbaan 28, 8024AA Zwolle, Netherlands"
     }
 }

--- a/testdata/noterror/nyc_godaddy.nyc
+++ b/testdata/noterror/nyc_godaddy.nyc
@@ -1,0 +1,101 @@
+Domain Name: godaddy.nyc
+Registry Domain ID: D116947-NYC
+Registrar WHOIS Server: whois.godaddy.com
+Registrar URL: whois.godaddy.com
+Updated Date: 2023-07-15T23:31:22Z
+Creation Date: 2014-10-03T15:38:57Z
+Registry Expiry Date: 2024-10-02T23:59:59Z
+Registrar: GoDaddy.com, LLC
+Registrar IANA ID: 146
+Registrar Abuse Contact Email: abuse@godaddy.com
+Registrar Abuse Contact Phone: +1.4806242505
+Domain Status: ok https://icann.org/epp#ok
+Registry Registrant ID: REDACTED FOR PRIVACY
+Registrant Name: REDACTED FOR PRIVACY
+Registrant Organization: Go Daddy Operating Company, LLC
+Registrant Street: REDACTED FOR PRIVACY
+Registrant Street: REDACTED FOR PRIVACY
+Registrant Street: REDACTED FOR PRIVACY
+Registrant City: REDACTED FOR PRIVACY
+Registrant State/Province: New York
+Registrant Postal Code: REDACTED FOR PRIVACY
+Registrant Country: US
+Registrant Phone: REDACTED FOR PRIVACY
+Registrant Phone Ext: REDACTED FOR PRIVACY
+Registrant Fax: REDACTED FOR PRIVACY
+Registrant Fax Ext: REDACTED FOR PRIVACY
+Registrant Email: Please query the RDDS service of the Registrar of Record identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Registry Admin ID: REDACTED FOR PRIVACY
+Admin Name: REDACTED FOR PRIVACY
+Admin Organization: REDACTED FOR PRIVACY
+Admin Street: REDACTED FOR PRIVACY
+Admin Street: REDACTED FOR PRIVACY
+Admin Street: REDACTED FOR PRIVACY
+Admin City: REDACTED FOR PRIVACY
+Admin State/Province: REDACTED FOR PRIVACY
+Admin Postal Code: REDACTED FOR PRIVACY
+Admin Country: REDACTED FOR PRIVACY
+Admin Phone: REDACTED FOR PRIVACY
+Admin Phone Ext: REDACTED FOR PRIVACY
+Admin Fax: REDACTED FOR PRIVACY
+Admin Fax Ext: REDACTED FOR PRIVACY
+Admin Email: Please query the RDDS service of the Registrar of Record identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Registry Tech ID: REDACTED FOR PRIVACY
+Tech Name: REDACTED FOR PRIVACY
+Tech Organization: REDACTED FOR PRIVACY
+Tech Street: REDACTED FOR PRIVACY
+Tech Street: REDACTED FOR PRIVACY
+Tech Street: REDACTED FOR PRIVACY
+Tech City: REDACTED FOR PRIVACY
+Tech State/Province: REDACTED FOR PRIVACY
+Tech Postal Code: REDACTED FOR PRIVACY
+Tech Country: REDACTED FOR PRIVACY
+Tech Phone: REDACTED FOR PRIVACY
+Tech Phone Ext: REDACTED FOR PRIVACY
+Tech Fax: REDACTED FOR PRIVACY
+Tech Fax Ext: REDACTED FOR PRIVACY
+Tech Email: Please query the RDDS service of the Registrar of Record identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Name Server: cns2.secureserver.net
+Name Server: cns1.secureserver.net
+DNSSEC: unsigned
+nyc ID: C116919-NYC
+nyc Name: REDACTED FOR PRIVACY
+nyc Organization: REDACTED FOR PRIVACY
+nyc Street: REDACTED FOR PRIVACY
+nyc Street: REDACTED FOR PRIVACY
+nyc Street: REDACTED FOR PRIVACY
+nyc City: REDACTED FOR PRIVACY
+nyc State/Province: REDACTED FOR PRIVACY
+nyc Postal Code: REDACTED FOR PRIVACY
+nyc Country: REDACTED FOR PRIVACY
+nyc Phone: REDACTED FOR PRIVACY
+nyc Phone Ext: REDACTED FOR PRIVACY
+nyc Fax: REDACTED FOR PRIVACY
+nyc Fax Ext: REDACTED FOR PRIVACY
+nyc Email:
+nyc Nexus Category: ORG
+URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2024-02-26T15:54:00Z <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
+
+The Service is provided so that you may look up certain information in relation to domain names that we store in our database.
+
+Use of the Service is subject to our policies, in particular you should familiarise yourself with our Acceptable Use Policy and our Privacy Policy.
+
+The information provided by this Service is 'as is' and we make no guarantee of it its accuracy.
+
+You agree that by your use of the Service you will not use the information provided by us in a way which is:
+* inconsistent with any applicable laws,
+* inconsistent with any policy issued by us,
+* to generate, distribute, or facilitate unsolicited mass email, promotions, advertisings or other solicitations, or
+* to enable high volume, automated, electronic processes that apply to the Service.
+
+You acknowledge that:
+* a response from the Service that a domain name is 'available', does not guarantee that is able to be registered,
+* we may restrict, suspend or terminate your access to the Service at any time, and
+* the copying, compilation, repackaging, dissemination or other use of the information provided by the Service is not permitted, without our express written consent.
+
+This information has been prepared and published in order to represent administrative and technical management of the TLD.
+
+We may discontinue or amend any part or the whole of these Terms of Service from time to time at our absolute discretion.

--- a/testdata/noterror/nyc_godaddy.nyc.json
+++ b/testdata/noterror/nyc_godaddy.nyc.json
@@ -1,0 +1,92 @@
+{
+    "domain": {
+        "id": "D116947-NYC",
+        "domain": "godaddy.nyc",
+        "punycode": "godaddy.nyc",
+        "name": "godaddy",
+        "extension": "nyc",
+        "whois_server": "whois.godaddy.com",
+        "status": [
+            "ok"
+        ],
+        "name_servers": [
+            "cns2.secureserver.net",
+            "cns1.secureserver.net"
+        ],
+        "created_date": "2014-10-03T15:38:57Z",
+        "created_date_in_time": "2014-10-03T15:38:57Z",
+        "updated_date": "2023-07-15T23:31:22Z",
+        "updated_date_in_time": "2023-07-15T23:31:22Z",
+        "expiration_date": "2024-10-02T23:59:59Z",
+        "expiration_date_in_time": "2024-10-02T23:59:59Z"
+    },
+    "registrar": {
+        "id": "146",
+        "name": "GoDaddy.com, LLC",
+        "phone": "+1.4806242505",
+        "email": "abuse@godaddy.com",
+        "referral_url": "whois.godaddy.com"
+    },
+    "registrant": {
+        "id": "REDACTED FOR PRIVACY",
+        "name": "REDACTED FOR PRIVACY",
+        "organization": "Go Daddy Operating Company, LLC",
+        "street": "REDACTED FOR PRIVACY, REDACTED FOR PRIVACY, REDACTED FOR PRIVACY",
+        "city": "REDACTED FOR PRIVACY",
+        "province": "New York",
+        "postal_code": "REDACTED FOR PRIVACY",
+        "country": "US",
+        "phone": "REDACTED FOR PRIVACY",
+        "phone_ext": "REDACTED FOR PRIVACY",
+        "fax": "REDACTED FOR PRIVACY",
+        "fax_ext": "REDACTED FOR PRIVACY",
+        "email": "please query the rdds service of the registrar of record identified in this output for information on how to contact the registrant, admin, or tech contact of the queried domain name."
+    },
+    "administrative": {
+        "id": "REDACTED FOR PRIVACY",
+        "name": "REDACTED FOR PRIVACY",
+        "organization": "REDACTED FOR PRIVACY",
+        "street": "REDACTED FOR PRIVACY, REDACTED FOR PRIVACY, REDACTED FOR PRIVACY",
+        "city": "REDACTED FOR PRIVACY",
+        "province": "REDACTED FOR PRIVACY",
+        "postal_code": "REDACTED FOR PRIVACY",
+        "country": "REDACTED FOR PRIVACY",
+        "phone": "REDACTED FOR PRIVACY",
+        "phone_ext": "REDACTED FOR PRIVACY",
+        "fax": "REDACTED FOR PRIVACY",
+        "fax_ext": "REDACTED FOR PRIVACY",
+        "email": "please query the rdds service of the registrar of record identified in this output for information on how to contact the registrant, admin, or tech contact of the queried domain name."
+    },
+    "technical": {
+        "id": "REDACTED FOR PRIVACY",
+        "name": "REDACTED FOR PRIVACY",
+        "organization": "REDACTED FOR PRIVACY",
+        "street": "REDACTED FOR PRIVACY, REDACTED FOR PRIVACY, REDACTED FOR PRIVACY",
+        "city": "REDACTED FOR PRIVACY",
+        "province": "REDACTED FOR PRIVACY",
+        "postal_code": "REDACTED FOR PRIVACY",
+        "country": "REDACTED FOR PRIVACY",
+        "phone": "REDACTED FOR PRIVACY",
+        "phone_ext": "REDACTED FOR PRIVACY",
+        "fax": "REDACTED FOR PRIVACY",
+        "fax_ext": "REDACTED FOR PRIVACY",
+        "email": "please query the rdds service of the registrar of record identified in this output for information on how to contact the registrant, admin, or tech contact of the queried domain name."
+    },
+    "nyc": {
+        "id": "C116919-NYC",
+        "name": "REDACTED FOR PRIVACY",
+        "organization": "REDACTED FOR PRIVACY",
+        "street": "REDACTED FOR PRIVACY, REDACTED FOR PRIVACY, REDACTED FOR PRIVACY",
+        "city": "REDACTED FOR PRIVACY",
+        "province": "REDACTED FOR PRIVACY",
+        "postal_code": "REDACTED FOR PRIVACY",
+        "country": "REDACTED FOR PRIVACY",
+        "phone": "REDACTED FOR PRIVACY",
+        "phone_ext": "REDACTED FOR PRIVACY",
+        "fax": "REDACTED FOR PRIVACY",
+        "fax_ext": "REDACTED FOR PRIVACY",
+        "extended_data": {
+            "nexus_category": "ORG"
+        }
+    }
+}

--- a/testdata/noterror/org_apache.org.json
+++ b/testdata/noterror/org_apache.org.json
@@ -22,8 +22,7 @@
         "updated_date": "2018-09-25T13:18:21.00Z",
         "updated_date_in_time": "2018-09-25T13:18:21Z",
         "expiration_date": "2022-04-12T04:00:00.00Z",
-        "expiration_date_in_time": "2022-04-12T04:00:00Z",
-        "reseller": "NAMECHEAP INC"
+        "expiration_date_in_time": "2022-04-12T04:00:00Z"
     },
     "registrar": {
         "id": "1068",
@@ -67,5 +66,8 @@
         "phone": "+1.1234567890",
         "fax": "+1.7816238460",
         "email": "dns@apache.org"
+    },
+    "reseller": {
+        "organization": "NAMECHEAP INC"
     }
 }

--- a/testdata/notfound/com_likexian-this-domain-doesnt-exist.com
+++ b/testdata/notfound/com_likexian-this-domain-doesnt-exist.com
@@ -1,0 +1,36 @@
+No match for "LIKEXIAN-THIS-DOMAIN-DOESNT-EXIST.COM".
+>>> Last update of whois database: 2024-02-29T19:44:28Z <<<
+
+NOTICE: The expiration date displayed in this record is the date the
+registrar's sponsorship of the domain name registration in the registry is
+currently set to expire. This date does not necessarily reflect the expiration
+date of the domain name registrant's agreement with the sponsoring
+registrar.  Users may consult the sponsoring registrar's Whois database to
+view the registrar's reported date of expiration for this registration.
+
+TERMS OF USE: You are not authorized to access or query our Whois
+database through the use of electronic processes that are high-volume and
+automated except as reasonably necessary to register domain names or
+modify existing registrations; the Data in VeriSign Global Registry
+Services' ("VeriSign") Whois database is provided by VeriSign for
+information purposes only, and to assist persons in obtaining information
+about or related to a domain name registration record. VeriSign does not
+guarantee its accuracy. By submitting a Whois query, you agree to abide
+by the following terms of use: You agree that you may use this Data only
+for lawful purposes and that under no circumstances will you use this Data
+to: (1) allow, enable, or otherwise support the transmission of mass
+unsolicited, commercial advertising or solicitations via e-mail, telephone,
+or facsimile; or (2) enable high volume, automated, electronic processes
+that apply to VeriSign (or its computer systems). The compilation,
+repackaging, dissemination or other use of this Data is expressly
+prohibited without the prior written consent of VeriSign. You agree not to
+use electronic processes that are automated and high-volume to access or
+query the Whois database except as reasonably necessary to register
+domain names or modify existing registrations. VeriSign reserves the right
+to restrict your access to the Whois database in its sole discretion to ensure
+operational stability.  VeriSign may restrict or terminate your access to the
+Whois database for failure to abide by these terms of use. VeriSign
+reserves the right to modify these terms at any time.
+
+The Registry database contains ONLY .COM, .NET, .EDU domains and
+Registrars.


### PR DESCRIPTION
- Fixed a bug for com/net domains that contain the word domain (Not sure if this issue exists for other TLDs)
- Added parsing for NYC contact
- Refactored contact comparison
- Converted reseller to it's own contact type